### PR TITLE
Notify user of conformance load and prevent test execution

### DIFF
--- a/app/controllers/servers/show.coffee
+++ b/app/controllers/servers/show.coffee
@@ -26,7 +26,12 @@ ServersShowController = Ember.Controller.extend({
       'Expand All'
   ).property('proxiedExpandedTests.length', 'tests.length')
 
-  # Boolean observer for determining if the server's conformance has loaded
+  # Boolean property for determining if we can execute selected tests
+  canExecuteTests: (->
+    !(@get('selectedTests.length') > 0)
+  ).property('selectedTests.length')
+
+  # Boolean property for determining if the server's conformance has loaded
   conformanceLoaded: (->
     @get('server.conformance.isLoaded') || false
   ).property('server.conformance')

--- a/app/controllers/servers/show.coffee
+++ b/app/controllers/servers/show.coffee
@@ -26,6 +26,11 @@ ServersShowController = Ember.Controller.extend({
       'Expand All'
   ).property('proxiedExpandedTests.length', 'tests.length')
 
+  # Boolean observer for determining if the server's conformance has loaded
+  conformanceLoaded: (->
+    @get('server.conformance.isLoaded') || false
+  ).property('server.conformance')
+
   actions:
     selectDeselectAll: ->
       # toggle the checkbox of 'selectDeselect' and toggle the checkboxes

--- a/app/templates/servers/show.hbs
+++ b/app/templates/servers/show.hbs
@@ -14,7 +14,7 @@
               {{#unless conformanceLoaded}}
                 <button type="submit" disabled class="btn" ><i class="fa fa-lg fa-fw fa-spinner fa-pulse"></i> Loading...</button>
               {{else}}
-                <button type="submit" class="btn" {{action "executeTests"}}>RUN</button>
+                <button type="submit" class="btn" {{bind-attr disabled="canExecuteTests"}} {{action "executeTests"}}>RUN</button>
               {{/unless}}
             {{/if}}
           </div>

--- a/app/templates/servers/show.hbs
+++ b/app/templates/servers/show.hbs
@@ -11,7 +11,11 @@
             {{#if savingTestRun}}
               <button type="submit" disabled class="btn" ><span class="glyphicon glyphicon-refresh glyphicon-refresh-animate"></span> Preparing...</button>
             {{else}}
-              <button type="submit" class="btn" {{action "executeTests"}}>RUN</button>
+              {{#unless conformanceLoaded}}
+                <button type="submit" disabled class="btn" ><i class="fa fa-lg fa-fw fa-spinner fa-pulse"></i> Loading...</button>
+              {{else}}
+                <button type="submit" class="btn" {{action "executeTests"}}>RUN</button>
+              {{/unless}}
             {{/if}}
           </div>
         </div>
@@ -32,7 +36,7 @@
         <div class="row">
           <ul class="nav nav-tabs tabbed-data-container">
             <li class="tabbed-data active"><a data-toggle="tab" href="#test-data">Tests</a></li>
-            <li class="tabbed-data"><a data-toggle="tab"href="#conformance-data">Conformance</a></li>
+            <li class="tabbed-data"><a data-toggle="tab"href="#conformance-data">{{#unless conformanceLoaded}}<i class="fa fa-lg fa-fw fa-spinner fa-pulse"></i> {{/unless}}Conformance</a></li>
             {{!-- <li class="tabbed-data"><a data-toggle="tab"href="#heatmap-data">Heat Map</a></li> --}}
           </ul>
         </div>


### PR DESCRIPTION
### Story ###
- [If a user executes tests before the server conformance is fetched, they will not see conformance results in test_runs.show](https://www.pivotaltracker.com/story/show/90952644)
- [Disable run button if no tests are selected.](https://www.pivotaltracker.com/story/show/91607344)

### Notes ###
- Added observer in ```servers.show``` controller to update conformance loading status in execution button and conformance tab
- Added another observer to update the execution button state to only allow execution if tests are actually selected

### Screenshot ###
![conformanceloading](https://cloud.githubusercontent.com/assets/456952/6926226/d6ff1b8e-d7b2-11e4-9687-6bddfcd41748.png)