### PR TITLE
Fixed Bug where scrolling was disabled after logging in & added login indicator when logging in

### DIFF
--- a/app/components/login-modal.coffee
+++ b/app/components/login-modal.coffee
@@ -3,7 +3,14 @@
 LoginModal = BootstrapModal.extend({
   identification: null
   password: null
+  loggingIn: false
   loginFailed: false
+  shouldCloseModal: false
+
+  _closeObserver: (->
+    @send('close') if @get('shouldCloseModal')
+    return
+  ).observes('shouldCloseModal').on('init')
 
   actions: {
     register: ->

--- a/app/controllers/modals/login.coffee
+++ b/app/controllers/modals/login.coffee
@@ -6,13 +6,17 @@ ModalsLoginController = Ember.Controller.extend(LoginControllerMixin, {
 
   identification: null
   password: null
+  loggingIn: false
   loginFailed: false
+  shouldCloseModal: false
 
   reset: ->
     @setProperties({
-      identification: null,
-      password: null,
+      identification: null
+      password: null
+      loggingIn: false
       loginFailed: false
+      shouldCloseModal: false
     })
 
   actions: {
@@ -24,18 +28,23 @@ ModalsLoginController = Ember.Controller.extend(LoginControllerMixin, {
 
       errorFn = (response) =>
         # log in failed, either invalid email or password
-        @set('loginFailed', true)
+        @setProperties({
+          loginFailed: true,
+          loggingIn: false
+        })
         return
 
       successFn = =>
-        @send('closeModal')
-        @reset()
+        @set('shouldCloseModal', true)
         return
 
       # wipe the failed message and make the AJAX call to log the user in
       # this._super() is defined by ember-simple-auth in
       # the LoginControllerMixin included in this controller
-      @set('loginFailed', false)
+      @setProperties({
+        loginFailed: false
+        loggingIn: true
+      })
       @_super().then(successFn, errorFn)
 
     register: ->

--- a/app/templates/components/login-modal.hbs
+++ b/app/templates/components/login-modal.hbs
@@ -28,7 +28,7 @@
           <div class="login-btn col-md-4">
             <button class="btn" type="submit" {{bind-attr disabled=loggingIn}}>
               {{#if loggingIn}}
-                <span class="glyphicon glyphicon-refresh glyphicon-refresh-animate"></span>
+                <span class="glyphicon glyphicon-refresh glyphicon-refresh-animate"> </span>
               {{/if}}
               Login
             </button>

--- a/app/templates/components/login-modal.hbs
+++ b/app/templates/components/login-modal.hbs
@@ -26,7 +26,12 @@
             <a href="">FORGOT PASSWORD</a> | <a href="/users/sign-up" {{action 'register'}}>REGISTER</a>
           </div>
           <div class="login-btn col-md-4">
-            <input class="btn" type="submit" value="Login">
+            <button class="btn" type="submit" {{bind-attr disabled=loggingIn}}>
+              {{#if loggingIn}}
+                <span class="glyphicon glyphicon-refresh glyphicon-refresh-animate"></span>
+              {{/if}}
+              Login
+            </button>
           </div>
         </div>
       </div>

--- a/app/templates/modals/login.hbs
+++ b/app/templates/modals/login.hbs
@@ -1,1 +1,1 @@
-{{login-modal fade=true close="close" register="register" submit="authenticate" loginFailed=loginFailed identification=identification password=password}}
+{{login-modal fade=true close="close" register="register" submit="authenticate" loginFailed=loginFailed identification=identification password=password shouldCloseModal=shouldCloseModal loggingIn=loggingIn}}


### PR DESCRIPTION
# Fixed Bug where Scrolling was Disabled after Logging In

* The problem existed because the modal was being removed by Ember, not Bootstrap.
* Added a `shouldCloseModel` property that runs the `close` action when set to `true`.

# Added Login Indicator when Logging In

* Added login indicator when logging in which disables the button. This is only noticable on slower machines.
* Added a `logginIn` property which displays the `glyphicon-refresh` icon and disables the Login button when set to `true`
 

![Conformance View](http://i.imgur.com/FOHCL5p.png?1)