### PR TITLE
Show summary times on landing page and server show page

### DIFF
--- a/app/models/summary.coffee
+++ b/app/models/summary.coffee
@@ -26,6 +26,13 @@ Summary = DS.Model.extend({
   failed: (->
     @get('compliance.failed')
   ).property('compliance.failed')
+
+  generatedFromNow: (->
+    if @get('testRun.date')
+      moment(@get('testRun.date')).fromNow()
+    else
+      '-'
+  ).property('testRun.date')
 })
 
 `export default Summary`

--- a/app/styles/_server.scss
+++ b/app/styles/_server.scss
@@ -129,7 +129,7 @@
 
     .server-time {
       font-size: .6em;
-      color: #777;
+      color: $base-header-small;
     }
   }
 }

--- a/app/styles/_server.scss
+++ b/app/styles/_server.scss
@@ -112,6 +112,7 @@
 
   .server-summary-details {
     margin: 10px;
+    margin-bottom: 0px;
 
     .server-name {
 
@@ -119,6 +120,16 @@
 
     .percent-passed {
       font-weight: bold;
+    }
+  }
+
+  .summary-time-details {
+    margin-bottom: 10px;
+    line-height: 1em;
+
+    .server-time {
+      font-size: .6em;
+      color: #777;
     }
   }
 }

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -7,6 +7,7 @@ $brand-accent: #7F9FC5;              // washed out blue
 $base: #EEEEEE;                      // background shade
 $base-lighten: #F5F5F5;              // background shade
 $base-darken: #DDDDDD;               // background shade darkened, used for hover
+$base-header-small: #777;            // gray used for small header text for summaries
 $structure: #DDD;                    // gray used for structural components
 
 $failure: #800010;

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -61,6 +61,9 @@
                 <span class="percent-passed">{{serverSummary.percentPassed}}%</span>
             </div>
           {{/link-to}}
+          <div class="summary-time-details">
+            <span class="server-time"><i class="fa fa-fw fa-clock-o"/> {{serverSummary.generatedFromNow}}</span>
+          </div>
         {{else}}
           <div class="server-summary-details">
             <i class="fa fa-fw fa-spinner fa-pulse"/> Loading...

--- a/app/templates/servers/show.hbs
+++ b/app/templates/servers/show.hbs
@@ -8,6 +8,9 @@
             <h1>
               {{model.server.name}}<br>
               <small>{{model.server.url}}</small>
+              <div class="pull-right">
+                <small><span class="server-time"><i class="fa fa-fw fa-clock-o"/> {{model.generatedFromNow}}</span></small>
+              </div>
             </h1>
 
           </div>


### PR DESCRIPTION
Landing page:
![screen shot 2015-05-20 at 1 53 36 pm](https://cloud.githubusercontent.com/assets/456952/7732683/8f1b71a2-fef7-11e4-8ca3-c5bd2ff81231.png)

Server show page:
![screen shot 2015-05-20 at 1 53 46 pm](https://cloud.githubusercontent.com/assets/456952/7732682/8f18e1a8-fef7-11e4-9565-db39eed7130d.png)