### PR TITLE
Only request servers and summaries for the landing page

### DIFF
--- a/app/models/summary.coffee
+++ b/app/models/summary.coffee
@@ -28,11 +28,11 @@ Summary = DS.Model.extend({
   ).property('compliance.failed')
 
   generatedFromNow: (->
-    if @get('testRun.date')
-      moment(@get('testRun.date')).fromNow()
+    if @get('generatedAt')
+      moment(@get('generatedAt')).fromNow()
     else
       '-'
-  ).property('testRun.date')
+  ).property('generatedAt')
 })
 
 `export default Summary`

--- a/app/routes/index.coffee
+++ b/app/routes/index.coffee
@@ -3,6 +3,8 @@
 
 IndexRoute = Ember.Route.extend(DefaultRoute, {
 
+  beforeModel: -> @store.findAll('server')
+
   model: ->
     @store.find("aggregate-summary", 0)
     # Ember.RSVP.hash(


### PR DESCRIPTION
### Notes ###
- trims requests from N summaries + N servers + N test runs to just 1 servers index + N summaries, which is sufficient data for the landing page
- time referenced in starburst subtitle now reflects the summary generation time rather than the test run execution time