### PR TITLE
Starburst filtering

### DIFF
--- a/app/components/test-run-result.coffee
+++ b/app/components/test-run-result.coffee
@@ -3,7 +3,6 @@
 TestRunResultComponent = Ember.Component.extend({
   proxiedResult: null
   result: Ember.computed.oneWay('proxiedResult.content')
-  id: Ember.computed.oneWay('proxiedResult.suite_id')
   filteredOut: Ember.computed.oneWay('proxiedResult.filteredOut')
 
   testRunResults: Ember.computed.oneWay('result.results')
@@ -21,10 +20,6 @@ TestRunResultComponent = Ember.Component.extend({
   actions:
     expandCollapse: ->
       @toggleProperty('proxiedResult.expanded')
-      return
-
-    test: ->
-      debugger
       return
 
 })

--- a/app/components/test-run-result.coffee
+++ b/app/components/test-run-result.coffee
@@ -2,8 +2,17 @@
 
 TestRunResultComponent = Ember.Component.extend({
   proxiedResult: null
-  filteredOut: Ember.computed.oneWay('proxiedResult.filteredOut')
   result: Ember.computed.oneWay('proxiedResult.content')
+  list: []
+  id: Ember.computed.oneWay('proxiedResult.suite_id')
+  filteredOut: (->
+    temp = @get('list')
+    if temp.contains(@get('id'))
+      return false
+    else
+      return true
+  ).property('list')
+
   testRunResults: Ember.computed.oneWay('result.results')
   selectedTestResult: ((key, value) ->
     return value if arguments.length > 1
@@ -19,6 +28,10 @@ TestRunResultComponent = Ember.Component.extend({
   actions:
     expandCollapse: ->
       @toggleProperty('proxiedResult.expanded')
+      return
+
+    test: ->
+      debugger
       return
 
 })

--- a/app/components/test-run-result.coffee
+++ b/app/components/test-run-result.coffee
@@ -2,12 +2,14 @@
 
 TestRunResultComponent = Ember.Component.extend({
   proxiedResult: null
+  filteredOut: Ember.computed.oneWay('proxiedResult.filteredOut')
   result: Ember.computed.oneWay('proxiedResult.content')
   testRunResults: Ember.computed.oneWay('result.results')
   selectedTestResult: ((key, value) ->
     return value if arguments.length > 1
     @get('testRunResults.firstObject')
   ).property('testRunResults.[]')
+
 
   _expandedObserver: (->
     @$('div.panel-collapse').collapse(if @get('proxiedResult.expanded') then 'show' else 'hide')

--- a/app/components/test-run-result.coffee
+++ b/app/components/test-run-result.coffee
@@ -3,15 +3,8 @@
 TestRunResultComponent = Ember.Component.extend({
   proxiedResult: null
   result: Ember.computed.oneWay('proxiedResult.content')
-  list: []
   id: Ember.computed.oneWay('proxiedResult.suite_id')
-  filteredOut: (->
-    temp = @get('list')
-    if temp.contains(@get('id'))
-      return false
-    else
-      return true
-  ).property('list')
+  filteredOut: Ember.computed.oneWay('proxiedResult.filteredOut')
 
   testRunResults: Ember.computed.oneWay('result.results')
   selectedTestResult: ((key, value) ->

--- a/app/components/test-run-results-filtered.coffee
+++ b/app/components/test-run-results-filtered.coffee
@@ -17,7 +17,9 @@ TestRunResultsFilteredComponent = Ember.Component.extend(
     @get('chartData.issues')
   ).property('chartData')
 
-  filteredSuites: Ember.computed.mapBy('issues', 'suite_id')
+  filteredSuites: (->
+    @get('issues')
+  ).property('issues')
 
   resultsBySuite: (-> 
     @get('overallData.testResults')
@@ -52,14 +54,14 @@ TestRunResultsFilteredComponent = Ember.Component.extend(
   
     updateCategories: (rootNode) ->
       @set('issues', rootNode.issues)
-      # list = Ember.computed.mapBy('rootNode.issues', 'suite_id')
-      # for result in @get('proxiedTestResults')
-      #   if list.contains(result.get('suite_id'))
-      #     debugger
-      #     result.set('filteredOut', false)
-      #   else 
-      #     result.set('filteredOut', true)
-
+      list = @get('filteredSuites').mapBy('suite_id')
+      debugger
+      for result in @get('proxiedTestResults')
+        id = result.get('suite_id')
+        if list.contains(id)
+          result.set('filteredOut', false)
+        else 
+          result.set('filteredOut', true)
       return
 
     groupByIndividualTests: ->

--- a/app/components/test-run-results-filtered.coffee
+++ b/app/components/test-run-results-filtered.coffee
@@ -13,23 +13,20 @@ TestRunResultsFilteredComponent = Ember.Component.extend(
   groupBySuite: true
   filterValue: null
 
-  issues: null
+  issues: (->
+    @get('chartData.issues')
+  ).property('chartData')
+
   filteredSuites: Ember.computed.mapBy('issues', 'suite_id')
 
   resultsBySuite: (-> 
     @get('overallData.testResults')
   ).property('overallData')
 
-
-  proxiedTestResults: Ember.computed.map('resultsBySuite', (result) -> Ember.Object.create(content: result, selected: false, expanded: false, suite_id: result.test.id, filteredOut: false) )
+  proxiedTestResults: Ember.computed.map('resultsBySuite', (result) -> Ember.Object.create(content: result, selected: false, expanded: false, suite_id: result.get('test.id'), filteredOut: false))
   selectedTests: Ember.computed.mapBy('proxiedSelectedTests', 'content')
   proxiedSelectedTests: Ember.computed.filterBy('proxiedTestResults', 'selected', true)
   proxiedExpandedTests: Ember.computed.filterBy('proxiedTestResults', 'expanded', true)
-
-  temp: ( ->  
-    values = @get('filteredSuites')
-    @get('proxiedTestResults').filter((suite) -> values.contains(suite.suite_id))
-  ).property('proxiedTestResults', 'filteredSuites')
 
   selectAllBtnText: (->
     if @get('groupBySuite')
@@ -55,7 +52,14 @@ TestRunResultsFilteredComponent = Ember.Component.extend(
   
     updateCategories: (rootNode) ->
       @set('issues', rootNode.issues)
-      @get('temp').setEach('filteredOut', true)
+      # list = Ember.computed.mapBy('rootNode.issues', 'suite_id')
+      # for result in @get('proxiedTestResults')
+      #   if list.contains(result.get('suite_id'))
+      #     debugger
+      #     result.set('filteredOut', false)
+      #   else 
+      #     result.set('filteredOut', true)
+
       return
 
     groupByIndividualTests: ->

--- a/app/components/test-run-results-filtered.coffee
+++ b/app/components/test-run-results-filtered.coffee
@@ -17,10 +17,6 @@ TestRunResultsFilteredComponent = Ember.Component.extend(
     @get('chartData.issues')
   ).property('chartData')
 
-  filteredSuites: (->
-    @get('issues')
-  ).property('issues')
-
   resultsBySuite: (-> 
     @get('overallData.testResults')
   ).property('overallData')
@@ -54,11 +50,10 @@ TestRunResultsFilteredComponent = Ember.Component.extend(
   
     updateCategories: (rootNode) ->
       @set('issues', rootNode.issues)
-      list = @get('filteredSuites').mapBy('suite_id')
-      debugger
+      filteredSuitesList = @get('issues').mapBy('suite_id')
       for result in @get('proxiedTestResults')
         id = result.get('suite_id')
-        if list.contains(id)
+        if filteredSuitesList.contains(id)
           result.set('filteredOut', false)
         else 
           result.set('filteredOut', true)

--- a/app/templates/components/test-run-result.hbs
+++ b/app/templates/components/test-run-result.hbs
@@ -1,5 +1,5 @@
 <div class="test-run-result {{if filteredOut 'filteredOut'}}">
-  <div class="toggleable panel-heading">
+  <div class="toggleable panel-heading" {{action 'test'}}>
     <h4 class="panel-title">
       {{input type="checkbox" name=result.test.id checked=proxiedResult.selected}}
       <a class="collapsed" data-toggle="collapse" data-target={{result.toggleSelector}} aria-expanded="false">

--- a/app/templates/components/test-run-result.hbs
+++ b/app/templates/components/test-run-result.hbs
@@ -1,5 +1,5 @@
 <div class="test-run-result {{if filteredOut 'filteredOut'}}">
-  <div class="toggleable panel-heading" {{action 'test'}}>
+  <div class="toggleable panel-heading">
     <h4 class="panel-title">
       {{input type="checkbox" name=result.test.id checked=proxiedResult.selected}}
       <a class="collapsed" data-toggle="collapse" data-target={{result.toggleSelector}} aria-expanded="false">

--- a/app/templates/components/test-run-results-filtered.hbs
+++ b/app/templates/components/test-run-results-filtered.hbs
@@ -10,7 +10,8 @@
     </div>
     <div>
       {{starburst-chart data=chartData on-zoom="updateCategories" selectedNode=currentNodeName showHeader=false}}
-      {{topLevelCategory}}
+      {{test}}
+      {{test1}}
     </div>
   </div>
 </div> 
@@ -27,7 +28,7 @@
   <div class="panel-group test-results" id="accordion" role="tablist" aria-multiselectable="true">
     <div class="{{if groupBySuite '' 'hidden'}}">
       {{#each proxiedTestResults as |result|}}
-        {{test-run-result proxiedResult=result filterValue=filterValue}}
+        {{test-run-result proxiedResult=result filterValue=filterValue list=filteredSuites}}
       {{/each}}
     </div>
     <div class="{{if groupBySuite 'hidden' ''}}">

--- a/app/templates/components/test-run-results-filtered.hbs
+++ b/app/templates/components/test-run-results-filtered.hbs
@@ -26,13 +26,10 @@
   <div class="panel-group test-results" id="accordion" role="tablist" aria-multiselectable="true">
     <div class="{{if groupBySuite '' 'hidden'}}">
       {{#each proxiedTestResults as |result|}}
-        {{test-run-result proxiedResult=result filterValue=filterValue list=filteredSuites}}
+        {{test-run-result proxiedResult=result filterValue=filterValue}}
       {{/each}}
     </div>
     <div class="{{if groupBySuite 'hidden' ''}}">
-<!--                     {{#each proxiedIndivResults as |result|}}
-        {{individual-test-result-panel proxiedIndivResult=result filterValue=filterValue}}
-      {{/each}} -->
       {{#each resultsBySuite as |result|}}
         {{#each result.results as |res|}}
           {{individual-test-result-panel individual_result=res filterValue=filterValue}}

--- a/app/templates/components/test-run-results-filtered.hbs
+++ b/app/templates/components/test-run-results-filtered.hbs
@@ -8,7 +8,7 @@
       <button type="button" class="btn secondary" {{action "selectDeselectAll"}}><i class="fa fa-check"></i>&nbsp;{{selectAllBtnText}}</button>
       <button type="button" class="btn secondary" {{action "expandCollapseAll"}}><i class="fa fa-expand"></i>&nbsp;{{expandCollapseBtnText}}</button>
     </div>
-    <div>
+    <div class="{{if groupBySuite '' 'hidden'}}">
       {{starburst-chart data=chartData on-zoom="updateCategories" selectedNode=currentNodeName showHeader=false}}
     </div>
   </div>

--- a/app/templates/components/test-run-results-filtered.hbs
+++ b/app/templates/components/test-run-results-filtered.hbs
@@ -8,9 +8,10 @@
       <button type="button" class="btn secondary" {{action "selectDeselectAll"}}><i class="fa fa-check"></i>&nbsp;{{selectAllBtnText}}</button>
       <button type="button" class="btn secondary" {{action "expandCollapseAll"}}><i class="fa fa-expand"></i>&nbsp;{{expandCollapseBtnText}}</button>
     </div>
-  <!--   <div>
+    <div>
       {{starburst-chart data=chartData on-zoom="updateCategories" selectedNode=currentNodeName showHeader=false}}
-    </div> -->
+      {{topLevelCategory}}
+    </div>
   </div>
 </div> 
 <!-- END: Left side, with filters -->

--- a/app/templates/components/test-run-results-filtered.hbs
+++ b/app/templates/components/test-run-results-filtered.hbs
@@ -10,8 +10,6 @@
     </div>
     <div>
       {{starburst-chart data=chartData on-zoom="updateCategories" selectedNode=currentNodeName showHeader=false}}
-      {{test}}
-      {{test1}}
     </div>
   </div>
 </div> 


### PR DESCRIPTION
Quick comment on what is going on here....

1. This is rebased with master and good to go 

2. the filtering starts but showing ALL test results. As soon as the starburst is clicked, the filtering is applied to the results. As such, since "issues" only holds the suite ID's WHERE ISSUES EXIST (i.e. failed), only the suites with issues will show (and thus be filtered) from there on out. 

Still having an issue with the "array flatten" stuff, so the filtering by starburst does not work for individual tests. As such, I hid the starburst for that panel. 